### PR TITLE
Add optional hand total display for blackjack

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -375,6 +375,7 @@ function App() {
         onInsurance={handleInsurance}
         learningMode={state.learningMode}
         learningModeEnabled={state.settings.learningModeEnabled}
+        showHandTotal={state.settings.showHandTotal}
       />
 
       {/* Betting Modal */}

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -6,6 +6,7 @@ interface GameSettings {
   autoDeal: boolean;
   lastBetAmount: number;
   soundEnabled?: boolean;
+  showHandTotal?: boolean;
 }
 
 interface SettingsProps {
@@ -70,6 +71,19 @@ export default function Settings({ settings, onUpdateSettings, isOpen, onClose }
           <ToggleSwitch
             enabled={settings.soundEnabled ?? true}
             onChange={() => handleToggle('soundEnabled')}
+          />
+        </div>
+
+        <div className="flex items-center justify-between">
+          <div>
+            <div className="text-white font-semibold">Show Hand Totals</div>
+            <div className="text-gray-400 text-sm">
+              Display hand values under cards (turn off to practice mental math)
+            </div>
+          </div>
+          <ToggleSwitch
+            enabled={settings.showHandTotal ?? true}
+            onChange={() => handleToggle('showHandTotal')}
           />
         </div>
       </div>

--- a/src/components/game/DealerArea.tsx
+++ b/src/components/game/DealerArea.tsx
@@ -4,9 +4,10 @@ import Hand from '../Hand';
 interface DealerAreaProps {
   cards: Card[];
   hideFirstCard: boolean;
+  showHandTotal?: boolean;
 }
 
-export default function DealerArea({ cards, hideFirstCard }: DealerAreaProps) {
+export default function DealerArea({ cards, hideFirstCard, showHandTotal = true }: DealerAreaProps) {
   return (
     <div className="bg-green-900/30 rounded-2xl p-3 mb-3 border border-green-600/30">
       <div className="text-center mb-2">
@@ -18,7 +19,7 @@ export default function DealerArea({ cards, hideFirstCard }: DealerAreaProps) {
             cards={cards}
             label=""
             hideFirstCard={hideFirstCard}
-            showValue={true}
+            showValue={showHandTotal}
           />
         ) : (
           <div className="text-green-600/50 text-lg">Dealer's cards will appear here</div>

--- a/src/components/game/GameTable.tsx
+++ b/src/components/game/GameTable.tsx
@@ -27,6 +27,7 @@ interface GameTableProps {
   onInsurance: () => void;
   learningMode?: LearningModeState;
   learningModeEnabled?: boolean;
+  showHandTotal?: boolean;
 }
 
 export default function GameTable({
@@ -48,6 +49,7 @@ export default function GameTable({
   onInsurance,
   learningMode,
   learningModeEnabled = false,
+  showHandTotal = true,
 }: GameTableProps) {
   return (
     <>
@@ -67,12 +69,14 @@ export default function GameTable({
           <DealerArea
             cards={dealerHand}
             hideFirstCard={phase === GAME_PHASES.PLAYER_TURN}
+            showHandTotal={showHandTotal}
           />
 
           <PlayerArea
             hands={playerHands}
             activeHandIndex={activeHandIndex}
             isPlayerTurn={phase === GAME_PHASES.PLAYER_TURN}
+            showHandTotal={showHandTotal}
           />
 
           {/* Player Controls - Now closer to the cards */}

--- a/src/components/game/PlayerArea.tsx
+++ b/src/components/game/PlayerArea.tsx
@@ -6,9 +6,10 @@ interface PlayerAreaProps {
   hands: PlayerHand[];
   activeHandIndex: number;
   isPlayerTurn: boolean;
+  showHandTotal?: boolean;
 }
 
-export default function PlayerArea({ hands, activeHandIndex, isPlayerTurn }: PlayerAreaProps) {
+export default function PlayerArea({ hands, activeHandIndex, isPlayerTurn, showHandTotal = true }: PlayerAreaProps) {
   return (
     <div className="bg-green-900/30 rounded-2xl p-3 mt-3 border border-green-600/30">
       <div className="text-center mb-2">
@@ -37,7 +38,7 @@ export default function PlayerArea({ hands, activeHandIndex, isPlayerTurn }: Pla
                   <Hand
                     cards={hand.cards}
                     label={handLabel}
-                    showValue={true}
+                    showValue={showHandTotal}
                   />
                   {hand.status === HAND_STATUS.BUST && (
                     <div className="text-center text-red-400 font-bold mt-2">BUST</div>

--- a/src/lib/gameState.ts
+++ b/src/lib/gameState.ts
@@ -49,6 +49,7 @@ interface GameSettings {
   showExpectedValue: boolean;
   soundEnabled?: boolean;
   animationsEnabled?: boolean;
+  showHandTotal?: boolean;
 }
 
 // Learning mode mistake tracking
@@ -202,6 +203,7 @@ export function createInitialState(config: GameConfig = DEFAULT_CONFIG): GameSta
     showExpectedValue: false,
     soundEnabled: true,
     animationsEnabled: true,
+    showHandTotal: true,
   };
   const settings: GameSettings = savedSettings ? { ...defaultSettings, ...JSON.parse(savedSettings) } : defaultSettings;
 


### PR DESCRIPTION
- Add showHandTotal setting to GameSettings (defaults to true)
- Add toggle in Settings modal with description
- Update PlayerArea and DealerArea to conditionally show hand totals
- Update GameTable to pass showHandTotal prop through
- Allows players to practice calculating hand values manually by hiding the totals